### PR TITLE
Home page presentational styles

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -43,8 +43,8 @@ function Feature({ title, description }) {
 }
 
 function Home() {
-  const mapiframe = `<script type="module" src="dist/mapml-viewer.js" ></script>
-  <mapml-viewer style="width:100%;height:490px;" projection="CBMTILE" zoom="5" lat="58" lon="-90" controls>
+  const mapiframe = `<script type="module" src="dist/mapml-viewer.js"></script>
+  <mapml-viewer style="width:100%;height:490px;border:0;" projection="CBMTILE" zoom="5" lat="58" lon="-90" controls>
     <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer->
   </mapml-viewer>`;
   const context = useDocusaurusContext();

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,7 +44,7 @@ function Feature({ title, description }) {
 
 function Home() {
   const mapiframe = `<script type="module" src="dist/mapml-viewer.js"></script>
-  <mapml-viewer style="width:100%;height:490px;border:0;" projection="CBMTILE" zoom="5" lat="58" lon="-90" controls>
+  <mapml-viewer style="width:100%;height:490px;border:0;background-color:#bfe8fc;" projection="CBMTILE" zoom="5" lat="58" lon="-90" controls>
     <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer->
   </mapml-viewer>`;
   const context = useDocusaurusContext();

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -15,6 +15,7 @@
 @media screen and (max-width: 966px) {
   .heroBanner {
     padding: 2rem;
+    max-width: 100%;    
   }
 }
 


### PR DESCRIPTION
I thought it'd be nice to add a background-color to `<mapml-viewer>` similar to that of the layer's background and remove the default border for a more seamless map.

Also adding CSS to prevent the banner's width from exceeding the viewport's width on small screens, causing an overflow on the x-axis.