### PR TITLE
Remove `is="web-map"` from `<mapml-viewer>`

### DIFF
--- a/docs/layers/static-features.md
+++ b/docs/layers/static-features.md
@@ -115,7 +115,7 @@ Sets the [extent](http://example.org/) of the layer.
 ## Full Examples
 
 ```html
-  <mapml-viewer style="height: 500px;width:500px;" is="web-map" projection="CBMTILE" zoom="2" lat="45.5052040" lon="-75.2202344"
+  <mapml-viewer style="height: 500px;width:500px;" projection="CBMTILE" zoom="2" lat="45.5052040" lon="-75.2202344"
     controls>
 
     <layer- label="Arizona" checked>


### PR DESCRIPTION
Probably an oversight to include `is="web-map"` from built-in `<map>` when copy & pasting.