### PR TITLE
Update logo & favicon

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ module.exports = {
   baseUrl: '/web-map-doc/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
-  favicon: 'img/favicon.ico',
+  favicon: 'https://maps4html.org/favicon.ico',
   organizationName: 'Maps4HTML', // Usually your GitHub org/user name.
   projectName: 'web-map-doc', // Usually your repo name.
   themeConfig: {
@@ -13,7 +13,7 @@ module.exports = {
       title: '<mapml-viewer>',
       logo: {
         alt: 'Maps4HTML Logo',
-        src: 'img/maps4html.png',
+        src: 'https://maps4html.org/favicon.ico',
       },
       items: [
         {


### PR DESCRIPTION
Uses https://maps4html.org/favicon.ico (added in https://github.com/Maps4HTML/Maps4HTML.github.io/pull/15) for both the logo and favicon.