### PR TITLE
Add Sync Repositories badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # web-map-element documentation
 
+![Sync Repositories](https://github.com/Maps4HTML/Web-Map-Custom-Element/workflows/Sync%20Repositories/badge.svg)
+
 ## What is the `<mapml-viewer>` and `<layer->` element suite?
 
 The `<mapml-viewer>` custom element is a prototype implementation of the


### PR DESCRIPTION
As [this repo is synced](https://github.com/Maps4HTML/Web-Map-Custom-Element/blob/e1264b86b897bbdeb7a3dd2ff7da31c3d53aa313/.github/workflows/sync.yml#L40) with Web-Map-Custom-Element it may as well display the badge.