### PR TITLE
Small updates to CSS and homepage's hero container

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: '<mapml-viewer> documentation',
-  tagline: 'A custom <mapml-viewer> and <layer-> element suite',
+  tagline: 'Embed map viewers into your web pages, using HTML only.',
   url: 'http://maps4html.org/web-map-doc/',
   baseUrl: '/web-map-doc/',
   onBrokenLinks: 'throw',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,14 +7,27 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #9bbe38;
+  --ifm-color-primary: #077d57;
+  /*
   --ifm-color-primary-dark: rgb(154, 187, 62);
   --ifm-color-primary-darker: rgb(150, 182, 62);
   --ifm-color-primary-darkest: rgb(131, 160, 52);
   --ifm-color-primary-light: rgb(179, 216, 78);
   --ifm-color-primary-lighter: rgb(189, 226, 85);
   --ifm-color-primary-lightest: rgb(209, 248, 101);
+  */
   --ifm-code-font-size: 95%;
+}
+
+a {
+  text-decoration: underline;
+}
+
+.menu a,
+.navbar a,
+.pagination-nav a,
+.table-of-contents a {
+  text-decoration: none;
 }
 
 .docusaurus-highlight-code-line {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -100,7 +100,7 @@ function Home() {
         )}
         <div className="container">
           <h2>Capabilities</h2>
-          <p>A thorough breakdown of the capabilities compared to other web map solutions can be found <a href="https://maps4html.org/UCR-MapML-Matrix/mapml-ucrs-fulfillment-matrix.html">here.</a>
+          <p>A thorough breakdown of the capabilities compared to other web map solutions can be found in the <a href="https://maps4html.org/UCR-MapML-Matrix/mapml-ucrs-fulfillment-matrix.html">MapML UCR Fulfillment Matrix</a>.
           </p>
           <br />
           <h2>Getting Involved</h2>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,7 +54,7 @@ function Home() {
       title="Home"
       description="Documentation for mapml-viewer and layer element suite">
 
-      <iframe tabIndex="-1" height="500px" width="100%" frameborder="0" scrolling="no" srcdoc={mapiframe}></iframe>
+      <iframe tabIndex="-1" height="500px" width="100%" frameBorder="0" scrolling="no" srcDoc={mapiframe}></iframe>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,7 +44,21 @@ function Feature({ title, description }) {
 
 function Home() {
   const mapiframe = `<script type="module" src="dist/mapml-viewer.js"></script>
-  <mapml-viewer style="width:100%;height:490px;border:0;background-color:#bfe8fc;" projection="CBMTILE" zoom="5" lat="58" lon="-90" controls>
+  <style>
+  html,
+  body {
+    height: 100%;
+  }
+  body {
+    margin: 0;
+  }
+  mapml-viewer {
+    width: 100%;
+    height: inherit;
+    background-color: #bfe8fc;
+  }
+  </style>
+  <mapml-viewer projection="CBMTILE" zoom="5" lat="58" lon="-90" frameborder="0" controls>
     <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer->
   </mapml-viewer>`;
   const context = useDocusaurusContext();
@@ -54,8 +68,8 @@ function Home() {
       title="Home"
       description="Documentation for mapml-viewer and layer element suite">
 
-      <iframe tabIndex="-1" height="500px" width="100%" frameBorder="0" scrolling="no" srcDoc={mapiframe}></iframe>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
+      <iframe tabIndex="-1" height="500px" width="100%" frameBorder="0" scrolling="no" srcDoc={mapiframe}></iframe>
         <div className="container">
 
           <h1 className="hero__title">{siteConfig.title}</h1>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -39,7 +39,7 @@
   padding: 2rem;
   pointer-events: none;
   border-radius: 2px;
-  background-color: #52626c;
+  background-color: #325b4e;
   mix-blend-mode: multiply;
   color: #fff;
   

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -6,17 +6,52 @@
  */
 
 .heroBanner {
+  position: relative;
+  background-color: #000;
+  min-height: 60vh;
+}
+
+[data-theme="light"] .heroBanner {
+  color: #000;
+}
+
+.heroBanner iframe {
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
   position: absolute;
-  overflow: hidden;
-  left: 50%;
-  transform: translateY(-28rem) translateX(-50%);
 }
 
 @media screen and (max-width: 966px) {
-  .heroBanner {
-    padding: 2rem;
-    max-width: 100%;    
+  .heroBanner iframe {
+    pointer-events: none;
   }
+  h1 {
+    font-size: 2.2rem!important;
+  }
+}
+
+.heroBanner iframe ~ div {
+  z-index: 2;
+  text-align: center;
+  width: auto;
+  padding: 2rem;
+  pointer-events: none;
+  border-radius: 2px;
+  background-color: #52626c;
+  mix-blend-mode: multiply;
+  color: #fff;
+  
+}
+.heroBanner iframe ~ div a {
+  pointer-events: auto;
+  color: inherit!important;
+}
+
+.heroBanner > div > h1,
+.heroBanner > div > p {
+  user-select: none;
 }
 
 .buttons {


### PR DESCRIPTION
https://github.com/Maps4HTML/web-map-doc/commit/9f062708ac078d89b0a2fca2d2116721658997d7 and https://github.com/Maps4HTML/web-map-doc/commit/1a14ce92ec1c4db4fcb7288d41e9bf5cfd891a99 changes styles and text in the homepage's hero container:

### Before
<img width="600" src="https://user-images.githubusercontent.com/26493779/122745478-55658080-d289-11eb-9676-beffa73162f0.png">

### After
<img width="600" src="https://user-images.githubusercontent.com/26493779/122745510-5c8c8e80-d289-11eb-98c1-5b81afc8d54a.png">

(I think this new tagline is more inviting to the average developer)

and also changes global link colors to a color that does not fail color contrast checks (before `#9bbe38` vs after `#077d57`).

https://github.com/Maps4HTML/web-map-doc/commit/c854fcae4b98525730ddc0d8c509cf8f04942abb fixes:
````console
Warning: Invalid DOM property `frameborder`. Did you mean `frameBorder`?
````
```console
Warning: Invalid DOM property `srcdoc`. Did you mean `srcDoc`?
``` 

