### PR TITLE
General update

### DIFF
--- a/docs/api/custom-projections.md
+++ b/docs/api/custom-projections.md
@@ -34,7 +34,6 @@ For example:
       map.projection = cProjection;
     </script>
    </head>
-   <body>
   <body>
     <mapml-viewer projection="ATLAS_POLAR_MAP" zoom="2" lat="83.48919" lon="-87.7687" controls>
       <layer- label="Atlas of Canada Polar Wall Map" checked>

--- a/docs/api/custom-projections.md
+++ b/docs/api/custom-projections.md
@@ -13,41 +13,41 @@ The `<mapml-viewer>` and `<map is="web-map">` custom elements provide the custom
 For example:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-   <head>
-     <meta charset="utf-8" >
-     <title>Example Custom Projection</title>
-     <meta name="viewport" content="width=device-width, initial-scale=1">
-     <script type="module" src="web-map/mapml-viewer.js"></script>
-     <script type="module">
-       let customProjectionDefinition = `{
-          "projection": "ATLAS_POLAR_MAP",
-          "proj4string" : "+proj=aeqd +lat_0=90 +lon_0=-90 +x_0=0 +y_0=0 +ellps=sphere +units=m +no_defs +type=crs",
-          "origin" : [-20015200,20015200],
-          "resolutions" :  [33073,16536.5,8268.246,4134.123,2067.061,1033.531,516.765],
-          "bounds" : [[4979939,-4846977],[-5139071,3980038]],
-          "tilesize" : 256
-        }`;
-      let map = document.querySelector("mapml-viewer");
-      let cProjection = map.defineCustomProjection(customProjectionDefinition);    
-      map.projection = cProjection;
-    </script>
-   </head>
-  <body>
-    <mapml-viewer projection="ATLAS_POLAR_MAP" zoom="2" lat="83.48919" lon="-87.7687" controls>
-      <layer- label="Atlas of Canada Polar Wall Map" checked>
-        <link rel="license" title="Canadian Federal Geospatial Platform" href="https://geoappext.nrcan.gc.ca/arcgis/rest/services/FGP/NCR_RCN/MapServer/">
-        <extent units="ATLAS_POLAR_MAP">
-          <input type="zoom" name="z" min="0" max="6" value="6" >
-          <input type="location" name="x" axis="column" units="tilematrix" min="116" max="186">
-          <input type="location" name="y" axis="row" units="tilematrix" min="125" max="184">
-          <link rel="tile" tref="https://geoappext.nrcan.gc.ca/arcgis/rest/services/FGP/NCR_RCN/MapServer/tile/{z}/{y}/{x}/">
-          <link rel="tile" tref="https://geoappext.nrcan.gc.ca/arcgis/rest/services/FGP/NCR_RCN_A/MapServer/tile/{z}/{y}/{x}/">
-        </extent>
-      </layer->
-    </mapml-viewer>
-  </body>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Example Custom Projection</title>
+  <script type="module" src="web-map/mapml-viewer.js"></script>
+  <script type="module">
+    let customProjectionDefinition = `{
+      "projection": "ATLAS_POLAR_MAP",
+      "proj4string" : "+proj=aeqd +lat_0=90 +lon_0=-90 +x_0=0 +y_0=0 +ellps=sphere +units=m +no_defs +type=crs",
+      "origin" : [-20015200,20015200],
+      "resolutions" :  [33073,16536.5,8268.246,4134.123,2067.061,1033.531,516.765],
+      "bounds" : [[4979939,-4846977],[-5139071,3980038]],
+      "tilesize" : 256
+      }`;
+    let map = document.querySelector("mapml-viewer");
+    let cProjection = map.defineCustomProjection(customProjectionDefinition);    
+    map.projection = cProjection;
+  </script>
+</head>
+<body>
+  <mapml-viewer projection="ATLAS_POLAR_MAP" zoom="2" lat="83.48919" lon="-87.7687" controls>
+    <layer- label="Atlas of Canada Polar Wall Map" checked>
+    <link rel="license" title="Canadian Federal Geospatial Platform" href="https://geoappext.nrcan.gc.ca/arcgis/rest/services/FGP/NCR_RCN/MapServer/">
+      <extent units="ATLAS_POLAR_MAP">
+        <input type="zoom" name="z" min="0" max="6" value="6" >
+        <input type="location" name="x" axis="column" units="tilematrix" min="116" max="186">
+        <input type="location" name="y" axis="row" units="tilematrix" min="125" max="184">
+        <link rel="tile" tref="https://geoappext.nrcan.gc.ca/arcgis/rest/services/FGP/NCR_RCN/MapServer/tile/{z}/{y}/{x}/">
+        <link rel="tile" tref="https://geoappext.nrcan.gc.ca/arcgis/rest/services/FGP/NCR_RCN_A/MapServer/tile/{z}/{y}/{x}/">
+      </extent>
+    </layer->
+  </mapml-viewer>
+</body>
 </html>
 ```
 

--- a/docs/api/mapml-viewer-api.md
+++ b/docs/api/mapml-viewer-api.md
@@ -28,7 +28,7 @@ the viewer through JavaScript.
 | Method                   	| Functionality                                                        	|
 |--------------------------	|----------------------------------------------------------------------	|
 | [back()](#back)                   	| Navigates back in the map's panning history.                         	|
-| defineCustomProjection() 	| Visit [this](custom-projections) for more information.                                       	|
+| defineCustomProjection() 	| Visit the [Custom Projections API](custom-projections) for more information.                                       	|
 | [forward()](#forward)                	| Navigates forward in the map's panning history.                      	|
 | [reload()](#reload)                 	| Clear the map's panning history and return to the starting location. 	|
 | [toggleDebug()](#toggledebug)            	| Toggle the debug functionality of the map.                           	|

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,15 +3,16 @@ id: installation
 title: Installation
 ---
 
-### Download `<mapml-viewer>` Suite
+## Download `<mapml-viewer>` Suite
 
 | Version | Description                                 |
 |---------|---------------------------------------------|
 | [master](https://github.com/Maps4HTML/Web-Map-Custom-Element/archive/master.zip)  | Latest version developed on `master` branch, needs to be built, using the [steps to clone the repository](/web-map-doc/docs/installation#clone-mapml-viewer-repository) |
 | [v0.8.0](https://github.com/Maps4HTML/Web-Map-Custom-Element/archive/v0.8.0.zip)  | Latest zip release                          |
 
-#### Using a Downloaded Version of `<mapml-viewer>` Suite
+### Using a Downloaded Version
 
+#### Extract the zip file
 Extract the zip file downloaded from the links above, in there you will find many files, the following are needed for full functionality:
 
 - layer.js
@@ -26,7 +27,7 @@ Extract the zip file downloaded from the links above, in there you will find man
 - proj4-src.js
 - proj4leaflet.js
 
-#### Adding Script To Webpage
+#### Add the Script to a Web page
 
 Copy/move these files to your webpage's directory and add the following to the `<head>` of your HTML code:
 
@@ -36,11 +37,11 @@ Copy/move these files to your webpage's directory and add the following to the `
 
 You can now use `<mapml-viewer>`, `<layer>` and the other elements that come in the `<mapml-viewer>` element suite on your webpages.
 
-### Clone `<mapml-viewer>` Repository
+## Clone `<mapml-viewer>` Repository
 
 An alternative to downloading the .zip file is to clone the github repository. This option allows you to make any modifications and view the source code more easily.
 
-#### Requirements
+### Requirements
 
 - [Node.js](https://nodejs.org/en/download/)
 
@@ -58,4 +59,4 @@ grunt clean copy rollup   #builds mapml
 ```
 
 After the build is complete a `dist` folder will be created with the contents.
-Follow the steps of [Using a Downloaded Version](/web-map-doc/docs/installation#using-a-downloaded-version-of-mapml-viewer-suite) on how to use the contents.
+See [Add the Script to a Web page](/web-map-doc/docs/installation#add-the-script-to-a-web-page) on how to use the contents.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ Copy/move these files to your webpage's directory and add the following to the `
 <script type="module" src="path/to/mapml-viewer.js"></script>
 ```
 
-You can now use `<mapml-viewer>`, `<layer>` and the other elements that come in the `<mapml-viewer>` element suite on your webpages.
+You can now use `<mapml-viewer>`, `<layer->` and the other elements that come in the `<mapml-viewer>` element suite on your webpages.
 
 ## Clone `<mapml-viewer>` Repository
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ title: Installation
 
 | Version | Description                                 |
 |---------|---------------------------------------------|
-| [master](https://github.com/Maps4HTML/Web-Map-Custom-Element/archive/master.zip)  | Latest version developed on `master` branch, needs to be built, steps can be found [here](/web-map-doc/docs/installation#clone-mapml-viewer-repository) |
+| [master](https://github.com/Maps4HTML/Web-Map-Custom-Element/archive/master.zip)  | Latest version developed on `master` branch, needs to be built, using the [steps to clone the repository](/web-map-doc/docs/installation#clone-mapml-viewer-repository) |
 | [v0.8.0](https://github.com/Maps4HTML/Web-Map-Custom-Element/archive/v0.8.0.zip)  | Latest zip release                          |
 
 #### Using a Downloaded Version of `<mapml-viewer>` Suite
@@ -57,4 +57,5 @@ npm install -g grunt-cli  #installs grunt command line tool
 grunt clean copy rollup   #builds mapml
 ```
 
-After the build is complete a dist folder will be created with the contents. Follow the steps [here](/web-map-doc/docs/installation#using-a-downloaded-version-of-mapml-viewer-suite) on how to use the contents.
+After the build is complete a `dist` folder will be created with the contents.
+Follow the steps of [Using a Downloaded Version](/web-map-doc/docs/installation#using-a-downloaded-version-of-mapml-viewer-suite) on how to use the contents.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ You can now use `<mapml-viewer>`, `<layer>` and the other elements that come in 
 
 An alternative to downloading the .zip file is to clone the github repository. This option allows you to make any modifications and view the source code more easily.
 
-#### Requreiments
+#### Requirements
 
 - [Node.js](https://nodejs.org/en/download/)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,7 @@ title: Installation
 ### Using a Downloaded Version
 
 #### Extract the zip file
+
 Extract the zip file downloaded from the links above, in there you will find many files, the following are needed for full functionality:
 
 - layer.js
@@ -32,7 +33,7 @@ Extract the zip file downloaded from the links above, in there you will find man
 Copy/move these files to your webpage's directory and add the following to the `<head>` of your HTML code:
 
 ```html
-  <script type="module" src="path/to/mapml-viewer.js"></script>
+<script type="module" src="path/to/mapml-viewer.js"></script>
 ```
 
 You can now use `<mapml-viewer>`, `<layer>` and the other elements that come in the `<mapml-viewer>` element suite on your webpages.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,9 +10,9 @@ For example, markup such as this:
 
 ```html
 <mapml-viewer projection="CBMTILE" zoom="3" lat="62.7" lon="-90.3" controls>
-    <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer->
-    <layer- label="Restaurants" src="demo/restaurants.mapml" checked></layer->
-    <layer- label="Canada's Provinces and Territories" src="demo/canada.mapml" checked></layer->
+  <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer->
+  <layer- label="Restaurants" src="demo/restaurants.mapml" checked></layer->
+  <layer- label="Canada's Provinces and Territories" src="demo/canada.mapml" checked></layer->
 </mapml-viewer>
 ```
 

--- a/docs/layers/static-features.md
+++ b/docs/layers/static-features.md
@@ -24,7 +24,6 @@ as you zoom in and out without distortion.
     </geometry>
   </feature>
 </layer->
-
 ```
 
 ## Associated Elements
@@ -62,7 +61,7 @@ This element contains the different points, lines and polygons that will be draw
 
 You can also provide a set of elements to further define the static feature layer. This is the list of available additions with examples.
 
-#### `<link rel="license">`
+### `<link rel="license">`
 
 Sets the attribution link of the layer. Example:
 
@@ -72,7 +71,7 @@ Sets the attribution link of the layer. Example:
 
 ---
 
-#### `<meta name="zoom">`
+### `<meta name="zoom">`
 
 Sets the native minimum and maximum [native zoom](http://example.org/). It also allows you to set a value, this is the default zoom of all features in the case the `<feature>` is missing a zoom attribute.
 
@@ -82,7 +81,7 @@ Sets the native minimum and maximum [native zoom](http://example.org/). It also 
 
 ---
 
-#### `<meta name="projection">`
+### `<meta name="projection">`
 
 Sets the [projection](http://example.org/) of the layer. 
 
@@ -92,7 +91,7 @@ Sets the [projection](http://example.org/) of the layer.
 
 ---
 
-#### `<meta name="cs">`
+### `<meta name="cs">`
 
 Sets the default [coordinate system](http://example.org/) of the layer. If a feature is missing the cs attribute, it will default to this, and if this is missing it will default to gcrs.
 
@@ -102,7 +101,7 @@ Sets the default [coordinate system](http://example.org/) of the layer. If a fea
 
 ---
 
-#### `<meta name="extent">`
+### `<meta name="extent">`
 
 Sets the [extent](http://example.org/) of the layer.
 

--- a/docs/layers/static-tiles.md
+++ b/docs/layers/static-tiles.md
@@ -39,7 +39,7 @@ Add an image file to your project directory. Now you can access this image in Ma
 
 You can also provide a set of elements to further define the static tile layer. This is the list of available additions with examples.
 
-#### `<link rel="license">` 
+### `<link rel="license">` 
 
 Sets the attribution link of the layer. Example:
 
@@ -49,7 +49,7 @@ Sets the attribution link of the layer. Example:
 
 ---
 
-#### `<meta name="zoom">` 
+### `<meta name="zoom">` 
 
 Sets the native minimum and maximum [native zoom](http://example.org/).
 
@@ -59,7 +59,7 @@ Sets the native minimum and maximum [native zoom](http://example.org/).
 
 ---
 
-#### `<meta name="projection">` 
+### `<meta name="projection">` 
 
 Sets the [projection](http://example.org/) of the layer. 
 

--- a/docs/layers/templated-features.md
+++ b/docs/layers/templated-features.md
@@ -78,7 +78,7 @@ In this section, we will learn how to create a templated feature layer. A templa
 
 You can also provide a set of elements to further define the templated feature layer. This is the list of available additions with examples.
 
-#### `<meta name="zoom">`
+### `<meta name="zoom">`
 Sets the zoom range of the layer. The layer will make requests from zoom levels 1 to 5 in the example below.
 
 ```html
@@ -86,6 +86,8 @@ Sets the zoom range of the layer. The layer will make requests from zoom levels 
 ```
 
 ---
+
+## Full Examples
 
 ```html
 <mapml-viewer projection="CBMTILE" zoom="3" lat="45.5052040" lon="-75.2202344" controls>

--- a/docs/layers/templated-images.md
+++ b/docs/layers/templated-images.md
@@ -80,7 +80,7 @@ In this section, we will learn how to create a templated image layer. A template
 
 You can also provide a set of elements to further define the templated tile layer. This is the list of available additions with examples.
 
-#### `<meta name="zoom">`
+### `<meta name="zoom">`
 Sets the zoom range of the layer, in the following example the user can zoom from zoom level 1 to 5. 
 
 ```html

--- a/docs/layers/templated-tiles.md
+++ b/docs/layers/templated-tiles.md
@@ -72,7 +72,7 @@ In this section, we will learn how to create a templated tile layer. A templated
 
 You can also provide a set of elements to further define the templated tile layer. This is the list of available additions with examples.
 
-#### `<meta name="zoom">`
+### `<meta name="zoom">`
 Sets the native minimum and maximum [native zoom](http://example.org/). It also allows you to set a value, this is the default zoom of all features in the case the `<feature>` is missing a zoom attribute.
 
 ```html

--- a/docs/maps/mapml-viewer.md
+++ b/docs/maps/mapml-viewer.md
@@ -34,6 +34,7 @@ The `<mapml-viewer>` element has several attributes to control the presentation 
 
 
 `projection` - an enumerated attribute. Case-sensitive values are: "`OSMTILE`", "`WGS84`", "`CBMTILE`" and "`APSTILE`".  
+The default projection is `OSMTILE`.
 
   - `OSMTILE` corresponds to the widely-used "Web Mercator" projected coordinate reference system, implying a "tile pyramid" zoom range from 0 to 23 (minimum tile size ~2.4m).
 

--- a/docs/maps/mapml-viewer.md
+++ b/docs/maps/mapml-viewer.md
@@ -9,25 +9,25 @@ slug: /maps/mapml-viewer
 The `<mapml-viewer>` element is the main element you can use to put a custom Web map on your page.  To create a (really) simple Web map, you might use it like this:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-   <head>
-     <meta charset="utf-8" >
-     <title>A Simple Web Map[tm]</title>
-     <meta name="viewport" content="width=device-width, initial-scale=1">
-     <script type="module" src="web-map/mapml-viewer.js"></script>
-     <style>
-     html, body {
-       height: 100%; /* These styles are required if you wish to use a % height
-                        value on the mapml-viewer element. */
-     }
-     </style>
-   </head>
-   <body>
-    <mapml-viewer projection="OSMTILE" zoom="0" lat="0.0" lon="0.0" controls>
-        <layer- label="OpenStreetMap" src="https://geogratis.gc.ca/mapml/en/osmtile/osm/" checked></layer->
-    </mapml-viewer>
-   </body>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>A Simple Web Map[tm]</title>
+  <script type="module" src="web-map/mapml-viewer.js"></script>
+  <style>
+    html, body {
+    height: 100%; /* These styles are required if you wish to use a % based
+                     height value on the mapml-viewer element. */
+    }
+  </style>
+</head>
+<body>
+  <mapml-viewer projection="OSMTILE" zoom="0" lat="0.0" lon="0.0" controls>
+    <layer- label="OpenStreetMap" src="https://geogratis.gc.ca/mapml/en/osmtile/osm/" checked></layer->
+  </mapml-viewer>
+</body>
 </html>    
 ```
 Note that for the above example to run properly on your own site, you need to get a built copy of the `<mapml-viewer>` project in your site's folder. In the example, the `<mapml-viewer>` files are copied into the folder named "web-map" in your site root folder. Your own site's path to these files will depend on how you structure your folders.

--- a/docs/maps/mapml-viewer.md
+++ b/docs/maps/mapml-viewer.md
@@ -16,6 +16,12 @@ The `<mapml-viewer>` element is the main element you can use to put a custom Web
      <title>A Simple Web Map[tm]</title>
      <meta name="viewport" content="width=device-width, initial-scale=1">
      <script type="module" src="web-map/mapml-viewer.js"></script>
+     <style>
+     html, body {
+       height: 100%; /* These styles are required if you wish to use a % height
+                        value on the mapml-viewer element. */
+     }
+     </style>
    </head>
    <body>
     <mapml-viewer projection="OSMTILE" zoom="0" lat="0.0" lon="0.0" controls>

--- a/docs/maps/web-map.md
+++ b/docs/maps/web-map.md
@@ -36,5 +36,5 @@ To experiment with the `web-map` and `map-area` custom elements, you should link
 
 In theory, if you take steps to provde the fallback markup, a normal (progressive) Web map experience will be had by most users, while those using an older browser or perhaps even Safari may get the "fallback" client side image map experience.  
 
-An older example of such a Web map may be found in [this](https://maps4html.org/Web-Map-Custom-Element/blog/progressive-web-maps.html) blog post.  Please raise an [issue](https://github.com/Maps4HTML/Web-Map-Custom-Element/issues) if you have comments about how that example works for you.
+An older example of such a Web map may be found in the [blog post on Progressive Web Maps](https://maps4html.org/Web-Map-Custom-Element/blog/progressive-web-maps.html).  Please raise an [issue](https://github.com/Maps4HTML/Web-Map-Custom-Element/issues) if you have comments about how that example works for you.
 

--- a/docs/maps/web-map.md
+++ b/docs/maps/web-map.md
@@ -12,9 +12,9 @@ The web-map custom element suite provides a set of proof-of-concept "[customized
 
 :::caution
 
-Note that because not all modern Web browsers implement HTML's customized built-in elements, it is not recommended to use this proof-of-concept on a public Web site, as end-user confusion may be the result.
+Note that because [not all modern Web browsers implement HTML's customized built-in elements](https://caniuse.com/mdn-api_customelementregistry_builtin), it is not recommended to use this proof-of-concept on a public Web site, as end-user confusion may be the result.
 
-Additionally, built-in elements are not accessible to screen reader users in some browsers due to a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1208405).
+Additionally, customized built-in elements are not accessible to screen reader users in some browsers due to a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1208405).
 :::
 
 The following markup may work on Chrome and Firefox, although it may take some fine tuning:

--- a/docs/maps/web-map.md
+++ b/docs/maps/web-map.md
@@ -14,6 +14,7 @@ The web-map custom element suite provides a set of proof-of-concept "[customized
 
 Note that because not all modern Web browsers implement HTML's customized built-in elements, it is not recommended to use this proof-of-concept on a public Web site, as end-user confusion may be the result.
 
+Additionally, built-in elements are not accessible to screen reader users in some browsers due to a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1208405).
 :::
 
 The following markup may work on Chrome and Firefox, although it may take some fine tuning:

--- a/docs/maps/web-map.md
+++ b/docs/maps/web-map.md
@@ -22,13 +22,13 @@ The following markup may work on Chrome and Firefox, although it may take some f
 ```html
 <img usemap="#mymap" src="../map1.png" width="700" height="400" alt="Map area">
 <map name="mymap" is="web-map" zoom="17" lat="45.398043" lon="-75.70683" controls>
-    <layer- id="osm" src="https://geogratis.gc.ca/mapml/osmtile/osm/" label="Open Street Map" checked></layer->
-    <layer- id="marker" label="Marker layer" src="../marker.mapml"></layer->
-    <area is="map-area" href='http://example.com/marker/' alt="rectangle" coords="255,145,275,190" shape="rect">
-    <area is="map-area" id="donut" alt="Circle" href='http://example.com/circle/' coords="250,250,25" shape="circle">
-    <area is="map-area" id="hole" coords="250,250,7" shape="circle">
-    <area is="map-area" id="rect" href='http://example.com/rectangle/' alt="Rectangle" coords="345,290,415,320" shape="rect">
-    <area is="map-area" id="poly" href='http://example.com/polygon/' alt="Polygon" coords="392,116,430,100,441,128,405,145" shape="poly">
+  <layer- id="osm" src="https://geogratis.gc.ca/mapml/osmtile/osm/" label="Open Street Map" checked></layer->
+  <layer- id="marker" label="Marker layer" src="../marker.mapml"></layer->
+  <area is="map-area" href='http://example.com/marker/' alt="rectangle" coords="255,145,275,190" shape="rect">
+  <area is="map-area" id="donut" alt="Circle" href='http://example.com/circle/' coords="250,250,25" shape="circle">
+  <area is="map-area" id="hole" coords="250,250,7" shape="circle">
+  <area is="map-area" id="rect" href='http://example.com/rectangle/' alt="Rectangle" coords="345,290,415,320" shape="rect">
+  <area is="map-area" id="poly" href='http://example.com/polygon/' alt="Polygon" coords="392,116,430,100,441,128,405,145" shape="poly">
 </map>
 ```
 

--- a/docs/other-elements/map-a.md
+++ b/docs/other-elements/map-a.md
@@ -23,7 +23,7 @@ wrapped it places a blue outline that is 1 pixel wide around the feature, that l
   - Defaults to `text/mapml`, in the absence of a valid type value.
   
 
-#### Target Behavior for `text/mapml`
+## Target Behavior for `text/mapml`
 
 | Target Value 	| Behavior                                              	|
 |--------------	|-------------------------------------------------------	|
@@ -32,7 +32,7 @@ wrapped it places a blue outline that is 1 pixel wide around the feature, that l
 | _parent      	| Replace all the layers with the linked URL layer.     	|
 | _top         	| Navigate the webpage to the linked URL.               	|
 
-#### Target Behavior for `text/html`
+## Target Behavior for `text/html`
 
 | Target Value 	| Behavior                                	|
 |--------------	|-----------------------------------------	|
@@ -41,7 +41,7 @@ wrapped it places a blue outline that is 1 pixel wide around the feature, that l
 | _parent      	| Navigate the webpage to the linked URL. 	|
 | _top         	| Navigate the webpage to the linked URL. 	|
 
-#### Location fragments
+## Location fragments
 
 If the `type` attribute's value is `text/mapml`, you have the ability add a location fragment
 to the URL. This will pan & zoom the map to the given location.
@@ -55,7 +55,7 @@ i.e. `<map-a href="#1, 20, 30">...</map-a>` will pan to latitude: 30, longitude:
 
 ## Examples
 
-#### Styling Linked Features
+### Styling Linked Features
 
 To style linked features simply target the `map-a` class in your CSS, once a link is clicked you can target the
 `map-a-visited` class. See the example below:
@@ -87,7 +87,7 @@ To style linked features simply target the `map-a` class in your CSS, once a lin
 
 ---
 
-#### Wrapping a Feature Type + Location Fragment 
+### Wrapping a Feature Type + Location Fragment 
 
 ```html
 <feature>
@@ -107,7 +107,7 @@ To style linked features simply target the `map-a` class in your CSS, once a lin
 This will replace the current layer with the layer within externalMapML.mapml, once it's added the map will then goto
 zoomlevel: 2, longitude: -98, latitude: 37.
 
-#### Wrapping a point coordinate with `target="_blank"` 
+### Wrapping a point coordinate with `target="_blank"` 
 
 ```html
 <feature>
@@ -124,7 +124,7 @@ zoomlevel: 2, longitude: -98, latitude: 37.
 
 In this example, a point will be created at (2954, 3210) which, once clicked, adds a new layer to the map.
 
-#### Nested `<map-a>` definition and behavior
+### Nested `<map-a>` definition and behavior
 
 ```html
 <feature>

--- a/docs/resources/debug-mode.md
+++ b/docs/resources/debug-mode.md
@@ -23,4 +23,4 @@ panel that display's the mouse's current location in the various coordinate syst
 
 #### Map's API
 
-Toggling debug mode can also be done through the viewer's api, see [here](../api/mapml-viewer-api.md#toggledebug) for more.
+Toggling debug mode can also be done through the viewer's API, see the [`toggleDebug()` method](../api/mapml-viewer-api.md#toggledebug) for more.

--- a/docs/resources/debug-mode.md
+++ b/docs/resources/debug-mode.md
@@ -14,13 +14,13 @@ panel that display's the mouse's current location in the various coordinate syst
 - the solid red line represents the layer's extent, if there are multiple layers the solid line may be a variety of colours
 - The bottom left panel displays the current mouse's position
 
-### Accessing Debug Mode
+## Accessing Debug Mode
 
-#### Map's Context Menu
+### Map's Context Menu
 
 ![The map in debug mode](../assets/img/toggle-debug.gif)
 
 
-#### Map's API
+### Map's API
 
 Toggling debug mode can also be done through the viewer's API, see the [`toggleDebug()` method](../api/mapml-viewer-api.md#toggledebug) for more.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,6 +69,10 @@ module.exports = {
               label: 'Twitter',
               href: 'https://twitter.com/maps4html',
             },
+            {
+              label: 'YouTube',
+              href: 'https://www.youtube.com/channel/UCKIv6IGwzxPF2HNhvq-VhKA',
+            },
           ],
         },
         {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -41,16 +41,35 @@ p, li, dt, dd, figcaption {
   max-width: 80ch;
 }
 
-@media (min-width: 997px) {
-  .navbar-sidebar {
-    display: none;
-  }
-}
-
 .menu--responsive .menu__button {
   color: #fff;
   background: var(--ifm-link-color);
   border: 0;
   box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
   min-height: 45px;
+}
+
+/* Fix Docusaurus tabbing issues */
+@media (max-width: 996px) {
+  .navbar--fixed-top:not(.navbar-sidebar--show) .navbar-sidebar__items {
+    display: none;
+  }
+  .navbar--fixed-top.navbar-sidebar--show:not(:focus-within) .navbar-sidebar,
+  .navbar--fixed-top.navbar-sidebar--show:not(:focus-within) .navbar-sidebar__backdrop {
+    display: none;
+  }
+}
+@media (min-width: 997px) {
+  .navbar-sidebar {
+    display: none;
+  }
+}
+body {
+  overflow-y: auto!important;
+}
+:focus {
+  outline-color: -webkit-focus-ring-color !important;
+  outline-style: auto !important;
+  outline-width: thin !important;
+  outline: revert !important;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -46,3 +46,11 @@ p, li, dt, dd, figcaption {
     display: none;
   }
 }
+
+.menu--responsive .menu__button {
+  color: #fff;
+  background: var(--ifm-link-color);
+  border: 0;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+  min-height: 45px;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,3 +36,7 @@ a {
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
+
+p, li, dt, dd, figcaption {
+  max-width: 80ch;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -40,3 +40,9 @@ a {
 p, li, dt, dd, figcaption {
   max-width: 80ch;
 }
+
+@media (min-width: 997px) {
+  .navbar-sidebar {
+    display: none;
+  }
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -69,7 +69,7 @@ function Home() {
       description="Documentation for mapml-viewer and layer element suite">
 
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <iframe tabIndex="-1" height="500px" width="100%" frameBorder="0" scrolling="no" srcDoc={mapiframe}></iframe>
+      <iframe tabIndex="-1" height="500px" width="100%" frameBorder="0" scrolling="no" title="MapML-viewer" srcDoc={mapiframe}></iframe>
         <div className="container">
 
           <h1 className="hero__title">{siteConfig.title}</h1>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,7 +20,7 @@ const features = [
     description: (
       <>
         This suite of elements enables fast and easy use of functions in an accessible manner.
-        Keyboard interaction and screen reader compatibility is contantly being improved.
+        Keyboard interaction and screen reader compatibility is constantly being improved.
       </>
     ),
   },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -55,7 +55,6 @@ function Home() {
   mapml-viewer {
     width: 100%;
     height: inherit;
-    background-color: #bfe8fc;
   }
   </style>
   <mapml-viewer projection="CBMTILE" zoom="5" lat="58" lon="-90" frameborder="0" controls>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -107,7 +107,7 @@ function Home() {
           <p>The custom element suite is an open source project. Anyone who wants to submit changes/fixes is welcomed to doing so through Pull Requests to our <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">Github Repository</a>.
             <br />
             <br />
-            You can also contribute by reporting any bugs or issues while using the element suite in the form of an issue on the same <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">Github Repository</a>.
+            You can also contribute by reporting any bugs or issues while using the element suite in the form of one or more <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element/issues">issues</a> on the same repository.
           </p>
         </div>
       </main>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -19,7 +19,8 @@ const features = [
     title: 'Accessible Maps',
     description: (
       <>
-        This suite of elements enables fast and easy use of functions in an accessible manner. Keyboard navigation and interaction is contantly being improved.
+        This suite of elements enables fast and easy use of functions in an accessible manner.
+        Keyboard interaction and screen reader compatibility is contantly being improved.
       </>
     ),
   },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,7 @@ const features = [
     title: 'Minimum Code',
     description: (
       <>
-        MapML prioritizes minimum code needed to create elaborate maps. No Javascript required, everything can be done using HTML + custom elements.
+        <a href="https://maps4html.org/MapML/spec/"><abbr title="Map Markup Language">MapML</abbr></a> prioritizes minimum code needed to create elaborate maps. No Javascript required, everything can be done using HTML + custom elements.
       </>
     ),
   },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -100,14 +100,16 @@ function Home() {
         )}
         <div className="container">
           <h2>Capabilities</h2>
-          <p>A thorough breakdown of the capabilities compared to other web map solutions can be found in the <a href="https://maps4html.org/UCR-MapML-Matrix/mapml-ucrs-fulfillment-matrix.html">MapML UCR Fulfillment Matrix</a>.
+          <p>
+          A thorough breakdown of the capabilities compared to other web map solutions can be found in the <a href="https://maps4html.org/UCR-MapML-Matrix/mapml-ucrs-fulfillment-matrix.html">MapML UCR Fulfillment Matrix</a>.
           </p>
-          <br />
+          
           <h2>Getting Involved</h2>
-          <p>The custom element suite is an open source project. Anyone who wants to submit changes/fixes is welcomed to doing so through Pull Requests to our <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">Github Repository</a>.
-            <br />
-            <br />
-            You can also contribute by reporting any bugs or issues while using the element suite in the form of one or more <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element/issues">issues</a> on the same repository.
+          <p>
+          The custom element suite is an open source project. Anyone who wants to submit changes/fixes is welcomed to doing so through Pull Requests to our <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">Github Repository</a>.
+          </p>
+          <p>
+          You can also contribute by reporting any bugs or issues while using the element suite in the form of one or more <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element/issues">issues</a> on the same repository.
           </p>
         </div>
       </main>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -7,7 +7,7 @@
 
 .heroBanner {
   position: relative;
-  background-color: #000;
+  background-color: #bfe8fc;
   min-height: 60vh;
 }
 


### PR DESCRIPTION
# Overview of changes

## Documentation
- [x] https://github.com/Maps4HTML/web-map-doc/commit/7f4df80bb44718c2950504ee10170f1470660f6c: State that `OSMTILE` is the default projection.
- [x] https://github.com/Maps4HTML/web-map-doc/commit/ab7460a48cec6537045d3805b590c3d6983aa879: Fix typo "Requreiments".
- [x] https://github.com/Maps4HTML/web-map-doc/commit/b5d54a1c869bd60c6c571faf294c5c2bb1535a0d: Specifically mention screen readers (in conjunction to keyboard interaction) under the 'Accessible Maps' section.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/ce70e9321e6c32a2f471e24be65ac40ee54c9e5a: Fix typo "contantly".
- [x] https://github.com/Maps4HTML/web-map-doc/commit/a68035ebab2cd0092516adb2aef1fd5d6444e6be: Mention the accessibility issue of customized built-in elements (and link to the Chromium bug).
  Closes https://github.com/Maps4HTML/web-map-doc/issues/27.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/3b6006ceb780bd234f419b84a6b93e593ce422db: Change `<layer>` to `<layer->`.

## HTML markup examples
- [x] https://github.com/Maps4HTML/web-map-doc/commit/b47199cd2ca38cc856ac2af19418cdf0df783dc8: Add back prerequisites for % based value height on mapml-viewer elements.
  Closes https://github.com/Maps4HTML/web-map-doc/issues/25.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/e6b3dd0485264826a39f71595f1a9c3ffaca0cc5: Remove duplicate `<body>` element in HTML example.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/b025a41833708802c08f1420f09698b625a33b8a: Uniform indentation in HTML examples (tab size: 2).
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/584859b558bacfbe3f43a26e41480a4bde9e07c1: Remove whitespace in the installation.md HTML example.

## Site functionality/visuals
- [x] https://github.com/Maps4HTML/web-map-doc/commit/c6b059ca898938aa64842ad150abf336c6214b7a Fixes an issue that causes a flash of black `background-color` in the `.heroBanner` (holds the home page's map viewer).
- [x] https://github.com/Maps4HTML/web-map-doc/commit/1533b85628d998150c8a58f59d89fc896388da39: Restrict some elements used in body to a `max-width` of 80 characters for readability.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/63b38af5b0b08537169bf55cde1c2ed65e986d4f: Add `title` to the map viewer iframe.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/16f16f87c6276dea9071e8802d023ceac3aadb92: Set the duplicate "mobile" menu to `display: none` on larger screen sizes, such that keyboard users don't tab to hidden menu items.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/8befc56c7a9f33efcd32db544832dfc610181942: Fix more Docusaurus keyboard tabbing issues.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/fd920492fbe429a4bfb17ba6d1e5ebefd6117053: Improve visibility of the bottom menu button on mobile.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/1111cfdcfdd3c6252765a3ee1df7ed432afee942: Correct heading levels (if we want smaller headings than the default we should use CSS). Notably this commit also changes some content in installation.md because not all steps of "Using a Downloaded Version" is applicable to the <q>Clone the repository</q> alternative.

## Link fixes/additions
- [x] https://github.com/Maps4HTML/web-map-doc/commit/93d5a7ebf28da93202999afc2618c5b2bd63f89c + https://github.com/Maps4HTML/web-map-doc/pull/28/commits/5f5fbcc51df7f7f0f6024884ee1cef0118ba8202: Replace "here" or "this" link text with descriptive text.
- [x] https://github.com/Maps4HTML/web-map-doc/commit/0293a854814af694496ea554281fc805fb7770ff: Link to support data for customized built-in elements.
- [x] https://github.com/Maps4HTML/web-map-doc/commit/ff7d0029aa3ca111f82ba8a2639ced487aaa613d: Rename one of the 2 links named "Github Repository" to "issues" (and link to the issue overview).
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/d8be2f15a9c68682e53725ff847405f6a361d117: Add link to the MapML spec where the term is first used.
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/14a3e07d9c39ff2b60f4a523d5125a99441ae56b: Add link to the Maps4HTML channel on YouTube in site's footer.

## Other
- [x] https://github.com/Maps4HTML/web-map-doc/pull/28/commits/56a9107fa41595c51f17b364b94eed3474c0bc50: Use `<p>` instead of `<br>`.