### PR TITLE
Example code cleanup

### DIFF
--- a/docs/api/custom-rendering.md
+++ b/docs/api/custom-rendering.md
@@ -14,7 +14,7 @@ To render custom tiles using JavaScript, listen for the `tileloadstart` event on
 ### `tileloadstart` Event
 
 This event is fired when a tile is first being created, the event contains the following structure in its detail property:
-```
+```js
 {
   x: 1,    // tilematrix x value of the tile loaded
   y: 2,    // tilematrix y value of the tile loaded
@@ -35,8 +35,8 @@ The map:
       <input name="zoomLevel" type="zoom" min="0" max="23" value="1" />
       <input name="row" type="location" axis="row" units="tilematrix" min="0" max="2" />
       <input name="col" type="location" axis="column" units="tilematrix" min="0" max="2" />
-
-      <link rel='tile' title='blank' tref='' /> //listen for the tileloadstart event on this element
+      <!-- listen for the tileloadstart event on this element -->
+      <link rel="tile" title="" tref="" />
     </extent>
   </layer->
 </mapml-viewer>

--- a/docs/layers/templated-tiles.md
+++ b/docs/layers/templated-tiles.md
@@ -14,7 +14,7 @@ In this section, we will learn how to create a templated tile layer. A templated
     <input name="zoomLevel" type="zoom" min="1" max="1" value="0" />
     <input name="row" type="location" axis="row" units="tilematrix" min="0" max="2" />
     <input name="col" type="location" axis="column" units="tilematrix" min="0" max="2" />
-    <link rel='tile' type='text/mapml' title='Templated Tiles' tref='tiles/{zoomLevel}/r{row}_c{col}.mapml' />
+    <link rel="tile" type="text/mapml" title="Templated Tiles" tref="tiles/{zoomLevel}/r{row}_c{col}.mapml" />
   </extent>
 </layer->
 ```
@@ -91,7 +91,7 @@ Sets the native minimum and maximum [native zoom](http://example.org/). It also 
       <input name="zoomLevel" type="zoom" min="1" max="1" value="0" />
       <input name="row" type="location" axis="row" units="tilematrix" min="0" max="2" />
       <input name="col" type="location" axis="column" units="tilematrix" min="0" max="2" />
-      <link rel='tile' type='text/mapml' title='Templated Tile Layer' tref='data/wgs84/{zoomLevel}/r{row}_c{col}.mapml' />
+      <link rel="tile" type="text/mapml" title="Templated Tile Layer" tref="data/wgs84/{zoomLevel}/r{row}_c{col}.mapml" />
     </extent>
   </layer->
 </mapml-viewer>

--- a/docs/maps/web-map.md
+++ b/docs/maps/web-map.md
@@ -24,11 +24,11 @@ The following markup may work on Chrome and Firefox, although it may take some f
 <map name="mymap" is="web-map" zoom="17" lat="45.398043" lon="-75.70683" controls>
   <layer- id="osm" src="https://geogratis.gc.ca/mapml/osmtile/osm/" label="Open Street Map" checked></layer->
   <layer- id="marker" label="Marker layer" src="../marker.mapml"></layer->
-  <area is="map-area" href='http://example.com/marker/' alt="rectangle" coords="255,145,275,190" shape="rect">
+  <area is="map-area" href="http://example.com/marker/" alt="rectangle" coords="255,145,275,190" shape="rect">
   <area is="map-area" id="donut" alt="Circle" href='http://example.com/circle/' coords="250,250,25" shape="circle">
   <area is="map-area" id="hole" coords="250,250,7" shape="circle">
-  <area is="map-area" id="rect" href='http://example.com/rectangle/' alt="Rectangle" coords="345,290,415,320" shape="rect">
-  <area is="map-area" id="poly" href='http://example.com/polygon/' alt="Polygon" coords="392,116,430,100,441,128,405,145" shape="poly">
+  <area is="map-area" id="rect" href="http://example.com/rectangle/" alt="Rectangle" coords="345,290,415,320" shape="rect">
+  <area is="map-area" id="poly" href="http://example.com/polygon/" alt="Polygon" coords="392,116,430,100,441,128,405,145" shape="poly">
 </map>
 ```
 

--- a/docs/other-elements/map-a.md
+++ b/docs/other-elements/map-a.md
@@ -63,11 +63,11 @@ To style linked features simply target the `map-a` class in your CSS, once a lin
 ```html
 <layer->
   <style>
-    .map-a{
-      stroke:red;
+    .map-a {
+      stroke: red;
     }
-    .map-a-visited{
-      stroke:green;
+    .map-a-visited {
+      stroke: green;
     }
   </style>
   <feature>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,6 +93,7 @@ module.exports = {
     },
     prism: {
       theme: require('prism-react-renderer/themes/duotoneLight'),
+      darkTheme: require('prism-react-renderer/themes/vsDark'),
     },
   },
   presets: [


### PR DESCRIPTION
Use double quotes everywhere. Add some needed spacing in `<style>` examples.

Also added a theme for syntax highlighting in dark mode.