### PR TITLE
Add new "`<layer->`" menu item

### DIFF
--- a/docs/layers/layer.md
+++ b/docs/layers/layer.md
@@ -1,0 +1,64 @@
+---
+id: layer
+title: <layer->
+slug: /layers/layer
+---
+
+A key abstraction in the world of mapping is that of "layer".  Maps have one or more layers.
+
+The map layer is implemented by the `<layer->` custom element.
+
+```html
+<layer- label="My Layer" checked>
+  ...layer content goes here...
+</layer->
+```
+
+`<layer->` is not a 'void' element - it must be closed with a `</layer->` tag.
+
+Map content can either be inline, as shown above - between the beginning `<layer->` and ending `</layer->` tags -
+or fetched, from the `<layer- src="..."></layer->` source attribute URL:
+
+```html
+<layer- label="My Layer" src="https://example.org/mapml/mylayer" checked></layer->
+```
+
+This documentation uses the convention of inline content mostly.  Fetched map content
+follows similar semantics, except it is parsed with the browser's XML parser and
+so must follow both MapML document conventions as well as
+[XML syntax rules](https://developer.mozilla.org/en-US/docs/Web/XML/XML_introduction).
+
+## Attributes
+
+### `src`
+
+Contains the path to a MapML document.
+
+### `checked`
+
+The `<layer- checked>` attribute and property is boolean. When present,
+the checked property value is taken to be 'true'; when not present, the property
+value is 'false'.  Beware that it is the _presence_ of the attribute that makes it
+true, not the value of the attribute. For example, the attribute `checked="false"`
+actually turns out to be checked,
+[as described by MDN Web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#boolean_attributes).
+
+### `disabled`
+
+The `<layer- disabled>` attribute and property is boolean. When present,
+sets the disabled state of the layer in the layer control.
+
+### `hidden`
+
+The `<layer- hidden>` attribute and property is boolean. When present,
+the layer is hidden in the layer control.
+
+### `label`
+
+The `label` attribute is used by inline content as the displayed text label of the
+layer in the layer control.  In fetched content, the `label` attribute is ignored,
+and the fetched `<title>` element is used.
+
+## API
+
+A [`<layer-> API`](../api/layer-api.md) is available.

--- a/docs/maps/mapml-viewer.md
+++ b/docs/maps/mapml-viewer.md
@@ -4,8 +4,6 @@ title: <mapml-viewer>
 slug: /maps/mapml-viewer
 ---
 
-## Introduction
-
 The `<mapml-viewer>` element is the main element you can use to put a custom Web map on your page.  To create a (really) simple Web map, you might use it like this:
 
 ```html
@@ -36,8 +34,9 @@ Note that for the above example to run properly on your own site, you need to ge
 
 The `<mapml-viewer>` element has several attributes to control the presentation and initial location of the map.  
 
-### Attributes
+## Attributes
 
+### `projection`
 
 `projection` - an enumerated attribute. Case-sensitive values are: "`OSMTILE`", "`WGS84`", "`CBMTILE`" and "`APSTILE`".  
 The default projection is `OSMTILE`.
@@ -52,12 +51,26 @@ The default projection is `OSMTILE`.
 
   - other projections are possible, using the [Custom Projections API](../api/custom-projections).
 
+### `zoom`
+
 `zoom` - a non-negative integer.  The value establishes the initial zoom level of the map.  For a small scale view of the world, use a lower value.  Use larger values for larger scales (smaller area maps). The maximum value depends on the particular `projection` and data source. Many map data sources have limited zoom levels available.
+
+### `lat`
 
 `lat` - a real number latitude. The value establishes the initial latitude of the of the center of the map. Latitudes on Earth range from -90.0 (south) to 90.0 (north).  Many projections are not able to display all latitudes, and most projections have a limited range of locations where distortion is controlled or limited. In particular, OSMTILE (Web Mercator) can only display content between the latitude range -84 to 84.
 
+### `lon`
+
 `lon` - a real number longitude. The value establishes the initial longitude of the of the center of the map.Longitudes on Earth range from -180.0 (west) to 180.0 (east). Similar comments related to distortion apply to those for latitude. Be careful, this attribute is named "lon" NOT "long", and if you use "long" your map won't work properly.
+
+### `controls`
 
 `controls` - a "boolean" attribute. Turns map controls on (if present) or off (if omitted). In HTML "boolean" attributes don't have values of "true" or "false" per se - they have the implied value of "true" if the attribute exists, and an implied value of "false" if the attribute is not present.  Sometimes the default map controls may not be useful for your map, so you may turn them off and design your own.
 
+### `controlslist`
+
 `controlslist` - an enumerated attribute, possible values are: "`nofullscreen`", "`nolayer`", "`noreload`" and "`nozoom`".  Occasionally, you may not want your users to have access to a particular control, so you may prune the set of controls automatically presented (when you have used the `controls` boolean attribute).
+
+## API
+
+A [`<mapml-viewer> API`](../api/mapml-viewer-api.md) is available.

--- a/sidebars.js
+++ b/sidebars.js
@@ -9,6 +9,7 @@ module.exports = {
       'maps/web-map',
       {
         'Layers': [
+          'layers/layer',
           'layers/static-tiles',
           'layers/static-features',
           'layers/static-images',


### PR DESCRIPTION
Close #32.

Additions to @prushforth's draft in https://github.com/Maps4HTML/web-map-doc/issues/32#issuecomment-890114694 include headings for the associated attributes (to expose them in the page's TOC). And a link to the API. These changes were reflected in mapml-viewer.md as well.

<hr>

Co-Authored-By: Peter Rushforth <2437285+prushforth@users.noreply.github.com>