### PR TITLE
Remove warning that setting HTMLLayerElement.label was not implemented

### DIFF
--- a/docs/api/layer-api.md
+++ b/docs/api/layer-api.md
@@ -76,10 +76,6 @@ via a local `<map-title>` element child of the `<layer->` element, or in the
 
 To set/update the `<layer->`'s label:
 
-:::caution
-Needs To Be Implemented, Currently doesn't update the label in layer controls
-:::
-
 ```js
 let layer = document.querySelector('layer-');
 layer.label = "New Title";

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/layer-api.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/layer-api.md
@@ -62,10 +62,6 @@ respectivement.
 
 Pour définir la label de `<layer->` ou mettre à jour celle-ci :
 
-:::caution
-Cette fonction n’est pas encore mise en œuvre. Ne met pas à jour l’étiquette au niveau du contrôle de la couche à l’heure actuelle.
-:::
-
 ```js
 let layer = document.querySelector('layer-');
 layer.label = "Nouveau titre";


### PR DESCRIPTION
When [this](https://github.com/Maps4HTML/Web-Map-Custom-Element/pull/865) is merged, we can merge this documentation update