### PR TITLE
Update documentation to reflect default cs of 'gcrs' for map-geometry

### DIFF
--- a/docs/elements/geometry.md
+++ b/docs/elements/geometry.md
@@ -13,8 +13,7 @@ A `<map-geometry>` element has one child element, which can be a `<map-point>`, 
 
 ### `cs`
 
-Defines the Coordinate System of the geometry. When no `cs` is provided, the coordinate system of descendant `<map-coordinates>` elements is determined by a fallback to any in-scope `<map-meta name="cs" content="...">`.  If no fallback coordinate system is identified by a `<map-meta>` element, the default value of `pcrs` (projected coordinates) is used.
-
+Defines the Coordinate System of the geometry. When no `cs` is provided, the coordinate system of descendant `<map-coordinates>` elements is determined by a fallback to any in-scope `<map-meta name="cs" content="...">`. If no fallback coordinate system is specified by a `<map-meta>` element, the default coordinate system of the `map-layer` is used; if none is defined, `gcrs` (geographic coordinates) is used.
 
 | CRS | Description |
 |------|-------------|
@@ -91,7 +90,6 @@ For each member geometry, the same non-schema constraints apply as to the unique
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Point</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-point class="point">
           <map-coordinates>-75.6916809 45.4186964</map-coordinates>
@@ -112,7 +110,6 @@ For each member geometry, the same non-schema constraints apply as to the unique
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Line</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-linestring class="line">
           <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255 -75.7236099 45.4208652 -75.7565689 45.4117074 -75.7833481 45.384225 -75.8197403 45.3714435 -75.8516693 45.377714</map-coordinates>
@@ -133,7 +130,6 @@ For each member geometry, the same non-schema constraints apply as to the unique
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygon</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon class="polygon">
           <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
@@ -155,7 +151,6 @@ For each member geometry, the same non-schema constraints apply as to the unique
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>MultiPoint</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-multipoint class="point">
           <map-coordinates>-75.7016373 45.4391764 -75.7236099 45.4208652 -75.7833481 45.384225</map-coordinates>
@@ -176,7 +171,6 @@ For each member geometry, the same non-schema constraints apply as to the unique
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>MultiLineString</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-multilinestring class="line">
           <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255</map-coordinates>
@@ -198,7 +192,6 @@ For each member geometry, the same non-schema constraints apply as to the unique
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>MultiPolygon</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-multipolygon class="polygon">
           <map-polygon>
@@ -224,7 +217,6 @@ For each member geometry, the same non-schema constraints apply as to the unique
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Geometry Collection</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-geometrycollection>
           <map-polygon class="polygon">

--- a/docs/elements/span.md
+++ b/docs/elements/span.md
@@ -21,7 +21,6 @@ The `<map-span>` element is useful when used together with html global attribute
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygon</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon>
           <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>

--- a/docs/elements/style.md
+++ b/docs/elements/style.md
@@ -43,7 +43,6 @@ All the demo's on the documentation pages contain a "CSS" tab which adds the CSS
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygon</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon>
           <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/elements/geometry.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/elements/geometry.md
@@ -13,7 +13,7 @@ Un élément `<map-geometry>` a un élément-enfant qui peut être `<map-point>`
 
 ### `cs`
 
-Définit le système de coordonnées de la géométrie. Si aucun `cs` n’est fourni, le système de coordonnées des éléments descendants `<map-coordinates>` est déterminé par un retour vers n’importe `<map-meta name="cs" content="...">` dans la portée. Si aucun système de coordonnées n’est identifié par un élément `<map-meta>`, la valeur par défaut de `pcrs` (coordonnées projetées) est utilisée.
+Définit le système de coordonnées de la géométrie. Si aucun `cs` n’est fourni, le système de coordonnées des éléments descendants `<map-coordinates>` est déterminé par un retour vers n’importe `<map-meta name="cs" content="...">` dans la portée. Si aucun système de coordonnées de secours n’est spécifié par un élément `<map-meta>`, le système de coordonnées par défaut du `map-layer` est utilisé; si aucun n'est défini, `gcrs` (coordonnées géographiques) est utilisé.
 
 Système de référence de coordonnées
 | CRS | Description |
@@ -91,7 +91,6 @@ Pour chaque géométrie membre, les mêmes contraintes non schéma s’appliquen
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Point</map-featurecaption>
-      <!—Les coordonnées de la géométrie sont celles du gcrs, puisque le système de référence des coordonnées par défaut est pcrs -->
       <map-geometry cs="gcrs">
         <map-point class="point">
           <map-coordinates>-75.6916809 45.4186964</map-coordinates>
@@ -112,7 +111,6 @@ Pour chaque géométrie membre, les mêmes contraintes non schéma s’appliquen
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Ligne</map-featurecaption>
-      <!—Les coordonnées de la géométrie sont celles de gcrs, puisque le système de référence des coordonnées par défaut est pcrs -->
       <map-geometry cs="gcrs">
         <map-linestring class="line">
           <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255 -75.7236099 45.4208652 -75.7565689 45.4117074 -75.7833481 45.384225 -75.8197403 45.3714435 -75.8516693 45.377714</map-coordinates>
@@ -133,7 +131,6 @@ Pour chaque géométrie membre, les mêmes contraintes non schéma s’appliquen
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygone</map-featurecaption>
-      <!-- Les coordonnées de la géométrie sont celles de gcrs, puisque le système de référence des coordonnées par défaut est pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon class="polygon">
           <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
@@ -155,7 +152,6 @@ Pour chaque géométrie membre, les mêmes contraintes non schéma s’appliquen
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>MultiPoint</map-featurecaption>
-      <!-- Les coordonnées de la géométrie sont celles de gcrs, puisque le système de référence des coordonnées par défaut est pcrs -->
       <map-geometry cs="gcrs">
         <map-multipoint class="point">
           <map-coordinates>-75.7016373 45.4391764 -75.7236099 45.4208652 -75.7833481 45.384225</map-coordinates>
@@ -176,7 +172,6 @@ Pour chaque géométrie membre, les mêmes contraintes non schéma s’appliquen
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>MultiLineString</map-featurecaption>
-      <!-- Les coordonnées de la géométrie sont celles de gcrs, puisque le système de référence des coordonnées par défaut est pcrs -->
       <map-geometry cs="gcrs">
         <map-multilinestring class="line">
           <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255</map-coordinates>
@@ -198,7 +193,6 @@ Pour chaque géométrie membre, les mêmes contraintes non schéma s’appliquen
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>MultiPolygon</map-featurecaption>
-      <!-- Les coordonnées de la géométrie sont celles de gcrs, puisque le système de référence des coordonnées par défaut est pcrs -->
       <map-geometry cs="gcrs">
         <map-multipolygon class="polygon">
           <map-polygon>
@@ -224,7 +218,6 @@ Pour chaque géométrie membre, les mêmes contraintes non schéma s’appliquen
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Collection de géométries</map-featurecaption>
-      <!-- Les coordonnées de la géométrie sont celles de gcrs, puisque le système de référence des coordonnées par défaut est pcrs -->
       <map-geometry cs="gcrs">
         <map-geometrycollection>
           <map-polygon class="polygon">

--- a/i18n/fr/docusaurus-plugin-content-docs/current/elements/span.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/elements/span.md
@@ -21,7 +21,6 @@ L’élément `<map-span>` est utile lorsqu’il est utilisé avec des attributs
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygone</map-featurecaption>
-      <!-- Régler les coordonnées de géométrie à gcrs, puisque la valeur par défaut correspond à pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon>
           <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/elements/style.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/elements/style.md
@@ -37,7 +37,6 @@ Toutes les démonstrations comprises dans les pages de documentation contiennent
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygone</map-featurecaption>
-      <!-- Régler les coordonnées de géométrie à gcrs, puisque la valeur par défaut correspond à pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon>
           <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>

--- a/static/demo/map-feature-demo/index.html
+++ b/static/demo/map-feature-demo/index.html
@@ -38,7 +38,6 @@
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygon</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon class="polygon">
           <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
@@ -49,7 +48,6 @@
 
     <map-feature>
       <map-featurecaption>Line</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-linestring class="line">
           <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255 -75.7236099 45.4208652 -75.7565689 45.4117074 -75.7833481 45.384225 -75.8197403 45.3714435 -75.8516693 45.377714</map-coordinates>
@@ -60,7 +58,6 @@
 
     <map-feature>
       <map-featurecaption>Point</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-point class="point">
           <map-coordinates>-75.6916809 45.4186964</map-coordinates>

--- a/static/demo/map-geometry-demo/index.html
+++ b/static/demo/map-geometry-demo/index.html
@@ -37,7 +37,6 @@
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Point</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-point class="point">
           <map-coordinates>-75.6916809 45.4186964</map-coordinates>

--- a/static/demo/map-link-demo/index.html
+++ b/static/demo/map-link-demo/index.html
@@ -38,7 +38,6 @@
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Ottawa</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-point class="ottawa">
           <map-coordinates>-75.697193 45.421530</map-coordinates>

--- a/static/demo/map-span-demo/index.html
+++ b/static/demo/map-span-demo/index.html
@@ -37,7 +37,6 @@
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygon</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon>
           <map-coordinates><map-span class="border">-75.8242035 45.3526278 -75.6793213 45.4572409 -75.5680847 45.4692806</map-span> -75.6092834 45.4215881 -75.5756378 45.3810901 -75.7946777 45.3120804 -75.8242035 45.3526278</map-coordinates>

--- a/static/demo/map-style-demo/index.html
+++ b/static/demo/map-style-demo/index.html
@@ -36,7 +36,6 @@
   <map-layer label="Points" checked>
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-geometrycollection>
           <map-point class="class1">

--- a/static/demo/sandbox/index.html
+++ b/static/demo/sandbox/index.html
@@ -37,7 +37,6 @@
     <map-meta name="projection" content="OSMTILE"></map-meta>
     <map-feature>
       <map-featurecaption>Polygon</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-polygon class="polygon">
           <map-coordinates>-75.5859375 45.4656690 -75.6813812 45.4533876 -75.6961441 45.4239978 -75.7249832 45.4083331 -75.7792282 45.3772317 -75.7534790 45.3294614 -75.5831909 45.3815724 -75.6024170 45.4273712 -75.5673981 45.4639834 -75.5859375 45.4656690</map-coordinates>
@@ -48,7 +47,6 @@
 
     <map-feature>
       <map-featurecaption>Line</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-linestring class="line">
           <map-coordinates>-75.6168365 45.471929 -75.6855011 45.458445 -75.7016373 45.4391764 -75.7030106 45.4259255 -75.7236099 45.4208652 -75.7565689 45.4117074 -75.7833481 45.384225 -75.8197403 45.3714435 -75.8516693 45.377714</map-coordinates>
@@ -59,7 +57,6 @@
 
     <map-feature>
       <map-featurecaption>Point</map-featurecaption>
-      <!-- Setting the geometry coordinates to gcrs, as the default is pcrs -->
       <map-geometry cs="gcrs">
         <map-point class="point">
           <map-coordinates>-75.6916809 45.4186964</map-coordinates>


### PR DESCRIPTION
closes #128

addresses documentation bug https://github.com/Maps4HTML/MapML-Specification/issues/257#issuecomment-3755208715